### PR TITLE
Revert "⬆️ Bump nokogiri from 1.18.9 to 1.19.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     minitest (5.17.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.3)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)


### PR DESCRIPTION
Reverts cardsofkeyforge/cardsofkeyforge.github.io#37